### PR TITLE
Fix hover_data error by avoiding duplicate product_name on merge

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,7 +324,10 @@ elif page == "比較ビュー":
         st.subheader("年計ライン比較")
         codes = comps["product_code"].tolist()
         data = st.session_state.data_year[st.session_state.data_year["product_code"].isin(codes)].copy()
-        data = data.merge(comps[["product_code","product_name","abc_class","tags"]], on="product_code", how="left")
+        # `data` already includes `product_name`; merging another `product_name` from
+        # `comps` creates `product_name_x`/`product_name_y` columns which break
+        # Plotly's `hover_data` lookup. Merge only the additional attributes.
+        data = data.merge(comps[["product_code","abc_class","tags"]], on="product_code", how="left")
         if params.get("index"):
             idx = build_indexed_series(st.session_state.data_year, codes)
             data = data.merge(idx, on=["product_code","month"], how="left")


### PR DESCRIPTION
## Summary
- Prevent duplicate `product_name` columns when merging comparables to the yearly data table
- Fixes Plotly error when `hover_data` references missing `product_name`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e40638fc832397dd281bdcac6340