### PR TITLE
Fix Plotly line opacity update

### DIFF
--- a/app.py
+++ b/app.py
@@ -340,7 +340,9 @@ elif page == "比較ビュー":
             if t.name == params.get("target_code"):
                 t.update(line={"width":4})
             else:
-                t.update(line={"width":1, "opacity":0.3})
+                # Plotly's `line` object does not support an `opacity` attribute.
+                # Apply transparency at the trace level instead.
+                t.update(line={"width":1}, opacity=0.3)
         if params.get("log"):
             fig.update_yaxes(type="log")
         st.plotly_chart(fig, use_container_width=True, height=500)


### PR DESCRIPTION
## Summary
- fix ValueError by applying opacity at the trace level instead of the line object

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4f6cf7c83238a7d6d98ce0f81f1