### PR TITLE
Use pivot_table to handle duplicate entries in yearly series

### DIFF
--- a/services.py
+++ b/services.py
@@ -542,5 +542,10 @@ def get_yearly_series(df_year: pd.DataFrame,
         df = df[df["month"] >= start]
     if end is not None:
         df = df[df["month"] <= end]
-    pivot = df.pivot(index="month", columns="product_code", values=metric).sort_index()
+    pivot = df.pivot_table(
+        index="month",
+        columns="product_code",
+        values=metric,
+        aggfunc="sum",
+    ).sort_index()
     return df, pivot


### PR DESCRIPTION
## Summary
- prevent ValueError when monthly/product codes have duplicates by aggregating with pivot_table

## Testing
- `python3 -m py_compile services.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2486d98d08323aeba61f10c9055f0