### PR TITLE
Include slope_beta in snapshot for correlation analysis

### DIFF
--- a/services.py
+++ b/services.py
@@ -444,15 +444,19 @@ def latest_yearsum_snapshot(df_year: pd.DataFrame, end_month: str) -> pd.DataFra
     ----------
     pd.DataFrame
         product_code, product_name, year_sum, rank, yoy, delta の列を持つ
-        スナップショット。
+        スナップショット。slope_beta 列が存在する場合は併せて含める。
     """
     snap = df_year[df_year["month"] == end_month].copy()
     if snap.empty:
-        return pd.DataFrame(columns=["product_code", "product_name", "year_sum", "rank", "yoy", "delta"])
+        return pd.DataFrame(
+            columns=["product_code", "product_name", "year_sum", "rank", "yoy", "delta", "slope_beta"]
+        )
     snap = snap.dropna(subset=["year_sum"])
     snap = snap.sort_values("year_sum", ascending=False)
     snap["rank"] = np.arange(1, len(snap) + 1)
     cols = ["product_code", "product_name", "year_sum", "rank", "yoy", "delta"]
+    if "slope_beta" in snap.columns:
+        cols.append("slope_beta")
     return snap[cols]
 
 


### PR DESCRIPTION
## Summary
- ensure latest_yearsum_snapshot returns slope_beta when available so correlation analysis can include it

## Testing
- `python - <<'PY'
import pandas as pd
from services import latest_yearsum_snapshot

year_df = pd.DataFrame({'product_code':['A'],'product_name':['ProdA'],'month':['2024-04'],'year_sum':[100],'yoy':[0.1],'delta':[10],'slope_beta':[0.5]})
print(latest_yearsum_snapshot(year_df, '2024-04'))
PY`
- `python -m py_compile services.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27f706ddc8323867ae9cbdfbc9796