### PR TITLE
Add metrics utilities and sample data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ streamlit run app.py
 - ランキングで年計ゼロを除外するバー表示
 - CSV/XLSX/PDF（KPI+Top10）エクスポート
 - ビュー保存（閾値/ウィンドウ/単位）
+
+## 指標の数式
+- 年計 (MAT): \(MAT_t = \sum_{i=0}^{11} revenue_{t-i}\)
+- PVM分解: \(\Delta Rev = \sum_i (p_i^1 - p_i^0) q_i^0 + \sum_i p_i^0 (q_i^1 - q_i^0) + Mix\)
+
+## テスト
+`pytest -q`

--- a/core/export.py
+++ b/core/export.py
@@ -1,0 +1,20 @@
+"""エクスポートユーティリティ。"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Dict
+
+import pandas as pd
+
+
+def to_zip(tables: Dict[str, pd.DataFrame]) -> bytes:
+    """複数のデータフレームを ZIP (CSV) にまとめる。"""
+
+    buff = io.BytesIO()
+    with zipfile.ZipFile(buff, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, df in tables.items():
+            zf.writestr(f"{name}.csv", df.to_csv(index=False, encoding="utf-8-sig"))
+    buff.seek(0)
+    return buff.read()

--- a/core/io.py
+++ b/core/io.py
@@ -1,0 +1,37 @@
+"""入出力ユーティリティ。
+
+CSV/Excel の読み込みやエンコーディング判定を行う。
+"""
+
+from __future__ import annotations
+
+import io
+
+import chardet
+import pandas as pd
+
+
+def detect_encoding(data: bytes) -> str:
+    """バイト列から推定される文字コードを返す。"""
+    result = chardet.detect(data)
+    return result.get("encoding", "utf-8")
+
+
+def read_table(file: io.BytesIO, filename: str) -> pd.DataFrame:
+    """CSV/Excel ファイルを読み込む。
+
+    Args:
+        file: アップロードされたバイト列。
+        filename: 拡張子判定用の元ファイル名。
+
+    Returns:
+        ``pd.DataFrame``
+    """
+
+    data = file.read()
+    file.seek(0)
+    if filename.lower().endswith(".csv"):
+        enc = detect_encoding(data)
+        return pd.read_csv(io.BytesIO(data), encoding=enc)
+    else:
+        return pd.read_excel(file)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,79 @@
+"""指標計算モジュール。
+
+売上年計（MAT）やPVM分解など、ダッシュボードで使用する
+主要指標を純関数として定義する。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+def mat(series: pd.Series, window: int = 12) -> pd.Series:
+    """12カ月移動合計（MAT）を計算する。
+
+    Args:
+        series: 月次売上などの時系列。月順で並んでいること。
+        window: 集計対象の月数。通常は12。
+
+    Returns:
+        ``series`` と同じ長さの ``pd.Series``。
+        先頭 ``window-1`` 要素は ``NaN``。
+    """
+
+    if window <= 0:
+        raise ValueError("window は正の整数である必要があります。")
+    return series.rolling(window=window, min_periods=window).sum()
+
+
+@dataclass
+class PVMResult:
+    """PVM分解の結果。"""
+
+    price_effect: float
+    volume_effect: float
+    mix_effect: float
+    actual_diff: float
+
+
+def pvm(
+    df0: pd.DataFrame,
+    df1: pd.DataFrame,
+    *,
+    price_col: str = "unit_price",
+    qty_col: str = "qty",
+) -> PVMResult:
+    """価格(P)、数量(V)、ミックス(M)効果に売上差分を分解する。
+
+    Args:
+        df0: 基準期間のデータ。 ``price_col`` と ``qty_col`` を含むこと。
+        df1: 比較期間のデータ。 ``df0`` と同一商品のみを含む想定。
+        price_col: 単価列名。
+        qty_col: 数量列名。
+
+    Returns:
+        :class:`PVMResult`
+    """
+
+    merged = (
+        df0[[price_col, qty_col]]
+        .join(df1[[price_col, qty_col]], lsuffix="0", rsuffix="1", how="outer")
+        .fillna(0)
+    )
+    p0 = merged[f"{price_col}0"]
+    q0 = merged[f"{qty_col}0"]
+    p1 = merged[f"{price_col}1"]
+    q1 = merged[f"{qty_col}1"]
+
+    price_effect = ((p1 - p0) * q0).sum()
+    volume_effect = (p0 * (q1 - q0)).sum()
+    actual_diff = (p1 * q1 - p0 * q0).sum()
+    mix_effect = actual_diff - price_effect - volume_effect
+    return PVMResult(
+        price_effect=price_effect,
+        volume_effect=volume_effect,
+        mix_effect=mix_effect,
+        actual_diff=actual_diff,
+    )

--- a/core/preprocess.py
+++ b/core/preprocess.py
@@ -1,0 +1,35 @@
+"""前処理モジュール。"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def to_monthly(
+    df: pd.DataFrame,
+    date_col: str = "date",
+    revenue_col: str = "revenue",
+    qty_col: str = "qty",
+) -> pd.DataFrame:
+    """取引データを月次に集計する。"""
+
+    df = df.copy()
+    df[date_col] = pd.to_datetime(df[date_col])
+    df["year_month"] = df[date_col].dt.to_period("M").dt.to_timestamp()
+    agg = (
+        df.groupby("year_month")[[revenue_col, qty_col]]
+        .sum()
+        .reset_index()
+        .sort_values("year_month")
+    )
+    return agg
+
+
+def complete_months(df: pd.DataFrame, date_col: str = "year_month") -> pd.DataFrame:
+    """欠測月を0で補完する。"""
+
+    df = df.set_index(date_col)
+    all_months = pd.date_range(df.index.min(), df.index.max(), freq="MS")
+    df = df.reindex(all_months, fill_value=0)
+    df.index.name = date_col
+    return df.reset_index()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,15 @@ python-dateutil>=2.8
 openpyxl>=3.1
 XlsxWriter>=3.1
 reportlab>=4.0
+pyarrow
+duckdb
+statsmodels
+pmdarima
+python-pptx
+scipy
+scikit-learn
+chardet
+ruff
+black
+pytest
+hypothesis

--- a/sample_data/generate.py
+++ b/sample_data/generate.py
@@ -1,0 +1,51 @@
+"""サンプル取引データを生成するスクリプト。
+
+36か月、3チャネル、200SKU の擬似データを生成する。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+RNG = np.random.default_rng(0)
+
+CHANNELS = ["Online", "Store", "Wholesale"]
+CATEGORIES = ["A", "B", "C"]
+
+
+def generate_transactions(months: int = 36, n_sku: int = 200) -> pd.DataFrame:
+    dates = pd.date_range("2021-01-01", periods=months, freq="MS")
+    records = []
+    for ym in dates:
+        for sku in range(n_sku):
+            channel = RNG.choice(CHANNELS)
+            category = RNG.choice(CATEGORIES)
+            price = RNG.integers(100, 500)
+            qty = RNG.poisson(5)
+            if RNG.random() < 0.02:
+                qty = -qty  # 返品
+            revenue = price * qty
+            records.append(
+                {
+                    "date": ym + pd.Timedelta(days=int(RNG.integers(0, 27))),
+                    "order_id": f"{ym:%Y%m}-{sku:04d}",
+                    "channel": channel,
+                    "product_code": f"SKU{sku:04d}",
+                    "product_name": f"商品{sku:04d}",
+                    "category": category,
+                    "qty": qty,
+                    "unit_price": price,
+                    "revenue": revenue,
+                    "customer_id": f"C{RNG.integers(1000):04d}",
+                    "discount": 0.0,
+                    "returns_flag": qty < 0,
+                }
+            )
+    return pd.DataFrame(records)
+
+
+if __name__ == "__main__":
+    df = generate_transactions()
+    df.to_csv("sample_transactions.csv", index=False, encoding="utf-8-sig")
+    print("generated sample_transactions.csv")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.metrics import PVMResult, mat, pvm
+
+
+def test_mat_basic():
+    s = pd.Series(np.arange(1, 25))
+    result = mat(s, window=12)
+    assert result.isna().sum() == 11
+    assert result.dropna().iloc[0] == s.iloc[:12].sum()
+
+
+def test_pvm_decomposition():
+    df0 = pd.DataFrame({"unit_price": [100, 200], "qty": [10, 5]}, index=["A", "B"])
+    df1 = pd.DataFrame({"unit_price": [110, 190], "qty": [9, 6]}, index=["A", "B"])
+    res = pvm(df0, df1)
+    assert isinstance(res, PVMResult)
+    recon = res.price_effect + res.volume_effect + res.mix_effect
+    assert res.actual_diff == pytest.approx(recon, rel=1e-3)


### PR DESCRIPTION
## Summary
- add core modules for MAT and PVM calculations
- add I/O helpers, export utility, and sample data generator
- document formulas and add tests for metrics

## Testing
- `python -m black core sample_data tests/test_metrics.py`
- `ruff check core sample_data tests/test_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3046ab4bc8323a7ae7f23f40f4af8