### PR TITLE
Handle missing colorway in small multiples

### DIFF
--- a/app.py
+++ b/app.py
@@ -948,11 +948,12 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
     for i, code in enumerate(page_codes):
         g = df_long[df_long["product_code"] == code]
         disp = g["display_name"].iloc[0] if not g.empty else code
+        palette = fig.layout.colorway or px.colors.qualitative.Safe
         fig_s = px.line(
             g,
             x="month",
             y="year_sum_disp",
-            color_discrete_sequence=[fig.layout.colorway[i % len(fig.layout.colorway)]],
+            color_discrete_sequence=[palette[i % len(palette)]],
             custom_data=["display_name"],
         )
         fig_s.update_traces(

--- a/tests/test_colorway.py
+++ b/tests/test_colorway.py
@@ -1,0 +1,13 @@
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+def test_colorway_fallback():
+    fig = go.Figure()
+    palette = fig.layout.colorway or px.colors.qualitative.Safe
+    assert palette[0] == px.colors.qualitative.Safe[0]
+
+    fig.update_layout(colorway=["#111111", "#222222"])
+    palette2 = fig.layout.colorway or px.colors.qualitative.Safe
+    assert palette2[1] == "#222222"
+


### PR DESCRIPTION
## Summary
- avoid TypeError when figure colorway is None by defaulting to Plotly Safe palette
- add regression test for colorway fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3066e67108323ad823089c440269f