### PR TITLE
Add reusable chart card and toolbar for SKU detail

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -1,0 +1,292 @@
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from services import slopes_snapshot, shape_flags, top_growth_codes
+from core.plot_utils import add_latest_labels_no_overlap
+
+UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
+
+
+def marker_step(dates, target_points=24):
+    n = len(pd.unique(dates))
+    return max(1, round(n / target_points))
+
+
+def _ensure_css():
+    if st.session_state.get("_chart_css_injected"):
+        return
+    st.markdown(
+        """
+<style>
+.chart-card { position: relative; margin:.25rem 0 1rem; border-radius:12px;
+  border:1px solid rgba(113,178,255,.25); background:var(--background-color,#0f172a); }
+.chart-toolbar { position: sticky; top: -1px; z-index: 5;
+  display:flex; gap:.6rem; flex-wrap:wrap; align-items:center;
+  padding:.35rem .6rem; background: linear-gradient(180deg, rgba(113,178,255,.20), rgba(113,178,255,.10));
+  border-bottom:1px solid rgba(113,178,255,.35); }
+.chart-toolbar .stRadio, .chart-toolbar .stSelectbox, .chart-toolbar .stSlider,
+.chart-toolbar .stMultiSelect, .chart-toolbar .stCheckbox { margin-bottom:0 !important; }
+.chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:#e6f2ff; }
+.chart-toolbar .stSlider label { color:#e6f2ff; }
+.chart-body { padding:.15rem .4rem .4rem; }
+</style>
+""",
+        unsafe_allow_html=True,
+    )
+    st.session_state["_chart_css_injected"] = True
+
+
+def toolbar_sku_detail(multi_mode: bool):
+    _ensure_css()
+    ui = st.session_state.setdefault("ui", {})
+
+    a, b, c, d, e = st.columns([1.1, 1.6, 1.1, 1.0, 0.9])
+    with a:
+        period_opts = ["12ヶ月", "24ヶ月", "36ヶ月"]
+        period = st.radio(
+            "期間",
+            period_opts,
+            horizontal=True,
+            index=period_opts.index(ui.get("period", "24ヶ月")),
+        )
+        ui["period"] = period
+    with b:
+        node_opts = ["自動", "主要ノードのみ", "すべて", "非表示"]
+        node_mode = st.radio(
+            "ノード表示",
+            node_opts,
+            horizontal=True,
+            index=node_opts.index(ui.get("node_mode", "自動")),
+        )
+        ui["node_mode"] = node_mode
+    with c:
+        hover_opts = ["個別", "同月まとめ"]
+        hover_mode = st.radio(
+            "ホバー",
+            hover_opts,
+            horizontal=True,
+            index=hover_opts.index(ui.get("hover_mode", "個別")),
+        )
+        ui["hover_mode"] = hover_mode
+    with d:
+        op_opts = ["パン", "ズーム", "選択"]
+        op_mode = st.radio(
+            "操作",
+            op_opts,
+            horizontal=True,
+            index=op_opts.index(ui.get("op_mode", "パン")),
+        )
+        ui["op_mode"] = op_mode
+    with e:
+        peak_on = st.checkbox("ピーク表示", value=ui.get("peak_on", False))
+        ui["peak_on"] = peak_on
+
+    f, g, h, i = st.columns([1.0, 1.5, 1.4, 1.4])
+    with f:
+        unit_opts = ["円", "千円", "百万円"]
+        unit = st.radio(
+            "単位",
+            unit_opts,
+            horizontal=True,
+            index=unit_opts.index(ui.get("unit", "千円")),
+        )
+        ui["unit"] = unit
+    with g:
+        enable_avoid = st.checkbox("ラベル衝突回避", value=ui.get("enable_avoid", True))
+        ui["enable_avoid"] = enable_avoid
+        gap_px = st.slider("ラベル最小間隔(px)", 8, 24, ui.get("gap_px", 12))
+        ui["gap_px"] = gap_px
+    with h:
+        max_labels = st.slider("ラベル最大件数", 5, 20, ui.get("max_labels", 12))
+        ui["max_labels"] = max_labels
+    with i:
+        alt_side = st.checkbox("ラベル左右交互配置", value=ui.get("alt_side", True))
+        ui["alt_side"] = alt_side
+
+    slope_conf = None
+    if multi_mode:
+        j, k, l, m = st.columns([1.2, 1.6, 1.2, 1.6])
+        with j:
+            quick_opts = ["なし", "Top5", "Top10", "最新YoY上位", "直近6M伸長上位"]
+            quick = st.radio(
+                "クイック絞り込み",
+                quick_opts,
+                horizontal=True,
+                index=quick_opts.index(ui.get("quick", "なし")),
+            )
+            ui["quick"] = quick
+        with k:
+            n_win = st.slider("傾きウィンドウ（月）", 3, 12, ui.get("n_win", 6), 1)
+            ui["n_win"] = n_win
+            cmp_opts = ["以上", "未満"]
+            cmp_mode = st.radio(
+                "傾き条件",
+                cmp_opts,
+                horizontal=True,
+                index=cmp_opts.index(ui.get("cmp_mode", "以上")),
+            )
+            ui["cmp_mode"] = cmp_mode
+        with l:
+            thr_opts = ["円/月", "%/月", "zスコア"]
+            thr_type = st.radio(
+                "しきい値の種類",
+                thr_opts,
+                horizontal=True,
+                index=thr_opts.index(ui.get("thr_type", "円/月")),
+            )
+            ui["thr_type"] = thr_type
+        with m:
+            thr_val = st.number_input("しきい値", value=float(ui.get("thr_val", 100000.0)), step=10000.0)
+            ui["thr_val"] = float(thr_val)
+        s1, s2 = st.columns([1.2, 1.2])
+        with s1:
+            shape_opts = ["（なし）", "急勾配", "山（への字）", "谷（逆への字）"]
+            shape_pick = st.radio(
+                "形状抽出",
+                shape_opts,
+                horizontal=True,
+                index=shape_opts.index(ui.get("shape_pick", "（なし）")),
+            )
+            ui["shape_pick"] = shape_pick
+        with s2:
+            sens = st.slider("形状抽出の感度", 0.0, 1.0, ui.get("sens", 0.5), 0.05)
+            ui["sens"] = sens
+        slope_conf = dict(
+            n_win=n_win,
+            cmp_mode=cmp_mode,
+            thr_type=thr_type,
+            thr_val=float(thr_val),
+            shape_pick=shape_pick,
+            sens=sens,
+            quick=quick,
+        )
+    st.session_state["ui"] = ui
+    return dict(
+        period=period,
+        node_mode=node_mode,
+        hover_mode=hover_mode,
+        op_mode=op_mode,
+        peak_on=peak_on,
+        unit=unit,
+        enable_avoid=enable_avoid,
+        gap_px=gap_px,
+        max_labels=max_labels,
+        alt_side=alt_side,
+        slope_conf=slope_conf,
+    )
+
+
+def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
+    months = {"12ヶ月": 12, "24ヶ月": 24, "36ヶ月": 36}[tb["period"]]
+    dfp = df_long.sort_values("month").groupby("product_code").tail(months)
+    if selected_codes:
+        dfp = dfp[dfp["product_code"].isin(selected_codes)].copy()
+
+    scale = UNIT_SCALE[tb["unit"]]
+    dfp["year_sum_disp"] = dfp["year_sum"] / scale
+
+    if multi_mode and tb.get("slope_conf"):
+        sc = tb["slope_conf"]
+        snap = slopes_snapshot(dfp, n=sc["n_win"])
+        key = {"円/月": "slope_yen", "%/月": "slope_ratio", "zスコア": "slope_z"}[sc["thr_type"]]
+        mask = (snap[key] >= sc["thr_val"]) if sc["cmp_mode"] == "以上" else (snap[key] <= sc["thr_val"])
+        codes_by_slope = set(snap.loc[mask, "product_code"])
+        if sc.get("quick") and sc["quick"] != "なし":
+            snapshot = dfp.sort_values("month").groupby("product_code").tail(1)
+            if sc["quick"] == "Top5":
+                quick_codes = snapshot.nlargest(5, "year_sum")["product_code"]
+            elif sc["quick"] == "Top10":
+                quick_codes = snapshot.nlargest(10, "year_sum")["product_code"]
+            elif sc["quick"] == "最新YoY上位":
+                quick_codes = snapshot.dropna(subset=["yoy"]).sort_values("yoy", ascending=False).head(10)["product_code"]
+            elif sc["quick"] == "直近6M伸長上位":
+                quick_codes = top_growth_codes(dfp, dfp["month"].max(), window=6, top=10)
+            else:
+                quick_codes = snapshot["product_code"]
+            codes_by_slope = codes_by_slope & set(quick_codes)
+        if sc["shape_pick"] != "（なし）":
+            sh = shape_flags(
+                dfp,
+                window=max(8, sc["n_win"] * 2),
+                alpha_ratio=0.02 * (1.0 - sc["sens"]),
+                amp_ratio=0.06 * (1.0 - sc["sens"]),
+            )
+            pick_map = {
+                "急勾配": snap.loc[snap["slope_z"].abs() >= 1.5, "product_code"],
+                "山（への字）": sh.loc[sh["is_mountain"], "product_code"],
+                "谷（逆への字）": sh.loc[sh["is_valley"], "product_code"],
+            }
+            pick = pick_map.get(sc["shape_pick"])
+            dfp = dfp[dfp["product_code"].isin(set(pick).intersection(codes_by_slope))]
+        else:
+            dfp = dfp[dfp["product_code"].isin(codes_by_slope)]
+
+    fig = px.line(dfp, x="month", y="year_sum_disp", color="display_name", custom_data=["display_name"])
+    fig.update_yaxes(title_text=f"売上 年計（{tb['unit']}）", tickformat="~,d")
+    fig.update_traces(
+        mode="lines+markers",
+        hovertemplate="<b>%{customdata[0]}</b><br>月：%{x|%Y-%m}<br>年計：%{y:,.0f} {tb['unit']}<extra></extra>",
+    )
+    if band_range:
+        low, high = band_range
+        fig.add_hrect(y0=low / scale, y1=high / scale, fillcolor="green", opacity=0.12, line_width=0)
+
+    fig.update_layout(
+        dragmode={"パン": "pan", "ズーム": "zoom", "選択": "select"}[tb["op_mode"]],
+        hovermode="closest" if tb["hover_mode"] == "個別" else "x unified",
+    )
+
+    theme_is_dark = st.get_option("theme.base") == "dark"
+    halo = "#ffffff" if theme_is_dark else "#222222"
+    if tb["node_mode"] == "自動":
+        step = marker_step(dfp["month"])
+        df_nodes = (
+            dfp.sort_values("month")
+            .assign(_idx=dfp.sort_values("month").groupby("display_name").cumcount())
+            .query("(_idx % @step) == 0")
+        )
+    elif tb["node_mode"] == "主要ノードのみ":
+        g = dfp.sort_values("month").groupby("display_name")
+        latest = g.tail(1)
+        idxmax = dfp.loc[g["year_sum"].idxmax().dropna()]
+        idxmin = dfp.loc[g["year_sum"].idxmin().dropna()]
+        ystart = g.head(1)
+        df_nodes = pd.concat([latest, idxmax, idxmin, ystart]).drop_duplicates(["display_name", "month"])
+    elif tb["node_mode"] == "すべて":
+        df_nodes = dfp.copy()
+    else:
+        df_nodes = dfp.iloc[0:0].copy()
+
+    for name, d in df_nodes.groupby("display_name"):
+        fig.add_scatter(
+            x=d["month"],
+            y=d["year_sum_disp"],
+            mode="markers",
+            name=name,
+            legendgroup=name,
+            showlegend=False,
+            marker=dict(size=6, symbol="circle", line=dict(color=halo, width=2), opacity=0.95),
+            customdata=np.stack([d["display_name"]], axis=-1),
+            hovertemplate="<b>%{customdata[0]}</b><br>月：%{x|%Y-%m}<br>年計：%{y:,.0f} {tb['unit']}<extra></extra>",
+        )
+
+    if tb["enable_avoid"]:
+        add_latest_labels_no_overlap(
+            fig,
+            dfp.rename(columns={"year_sum_disp": "year_sum"}),
+            label_col="display_name",
+            x_col="month",
+            y_col="year_sum",
+            max_labels=tb["max_labels"],
+            min_gap_px=tb["gap_px"],
+            alternate_side=tb["alt_side"],
+        )
+
+    st.plotly_chart(
+        fig,
+        use_container_width=True,
+        config={"displaylogo": False, "scrollZoom": True, "doubleClick": "reset"},
+    )
+    return fig

--- a/core/plot_utils.py
+++ b/core/plot_utils.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+
+
+def _plot_area_height(fig: go.Figure) -> int:
+    h = fig.layout.height or 520
+    m = fig.layout.margin or {}
+    t = getattr(m, "t", 40) or 40
+    b = getattr(m, "b", 60) or 60
+    return max(120, int(h - t - b))
+
+
+def _y_to_px(y, y0, y1, plot_h):
+    if y1 == y0:
+        y1 = y0 + 1.0
+    return float((1 - (y - y0) / (y1 - y0)) * plot_h)
+
+
+def add_latest_labels_no_overlap(
+    fig: go.Figure,
+    df_long: pd.DataFrame,
+    label_col: str = "display_name",
+    x_col: str = "month",
+    y_col: str = "year_sum",
+    max_labels: int = 12,
+    min_gap_px: int = 12,
+    alternate_side: bool = True,
+    xpad_px: int = 8,
+    font_size: int = 11,
+):
+    last = df_long.sort_values(x_col).groupby(label_col, as_index=False).tail(1)
+    if len(last) == 0:
+        return
+    cand = last.sort_values(y_col, ascending=False).head(max_labels).copy()
+    yaxis = fig.layout.yaxis
+    if getattr(yaxis, "range", None):
+        y0, y1 = yaxis.range
+    else:
+        y0, y1 = float(df_long[y_col].min()), float(df_long[y_col].max())
+    plot_h = _plot_area_height(fig)
+    cand["y_px"] = cand[y_col].apply(lambda v: _y_to_px(v, y0, y1, plot_h))
+    cand = cand.sort_values("y_px")
+    placed = []
+    for _, r in cand.iterrows():
+        base = r["y_px"]
+        if placed and base <= placed[-1] + min_gap_px:
+            base = placed[-1] + min_gap_px
+        base = float(np.clip(base, 0 + 6, plot_h - 6))
+        placed.append(base)
+        yshift = -(base - r["y_px"])
+        xshift = xpad_px if (not alternate_side or (len(placed) % 2 == 1)) else -xpad_px
+        fig.add_annotation(
+            x=r[x_col],
+            y=r[y_col],
+            text=f"{r[label_col]}：{r[y_col]:,.0f}（{pd.to_datetime(r[x_col]).strftime('%Y-%m')}）",
+            showarrow=False,
+            xanchor="left" if xshift >= 0 else "right",
+            yanchor="middle",
+            xshift=xshift,
+            yshift=yshift,
+            bgcolor="rgba(0,0,0,0)",
+            bordercolor="rgba(0,0,0,0)",
+            font=dict(size=font_size),
+        )


### PR DESCRIPTION
## Summary
- Introduce shared chart card utilities with sticky toolbar, unit scaling and label collision avoidance
- Apply the new toolbar and chart renderer to SKU detail view for both single and multi comparison modes
- Refactor comparison view to reuse the chart card component

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b308ece20c8323890378d0f3086263