### PR TITLE
Fix duplicate year_sum column causing ValueError

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -275,10 +275,10 @@ def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
     if tb["enable_avoid"]:
         add_latest_labels_no_overlap(
             fig,
-            dfp.rename(columns={"year_sum_disp": "year_sum"}),
+            dfp,
             label_col="display_name",
             x_col="month",
-            y_col="year_sum",
+            y_col="year_sum_disp",
             max_labels=tb["max_labels"],
             min_gap_px=tb["gap_px"],
             alternate_side=tb["alt_side"],


### PR DESCRIPTION
## Summary
- Avoid renaming `year_sum_disp` to `year_sum` when adding latest labels
- Pass display values directly to `add_latest_labels_no_overlap` to keep column names unique

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30acee1f483238293b5a1f7fe2117