### PR TITLE
Enable auto slope window with safety guards

### DIFF
--- a/app.py
+++ b/app.py
@@ -591,7 +591,14 @@ elif page == "比較ビュー":
     with c13:
         unit = st.radio("単位", ["円", "千円", "百万円"], horizontal=True, index=1)
     with c14:
-        n_win = st.slider("傾きウィンドウ（月）", 3, 12, 6, 1)
+        n_win = st.slider(
+            "傾きウィンドウ（月）",
+            0,
+            12,
+            6,
+            1,
+            help="0=自動（系列の全期間で判定）",
+        )
     with c15:
         cmp_mode = st.radio("傾き条件", ["以上", "未満"], horizontal=True)
     with c16:
@@ -647,8 +654,13 @@ elif page == "比較ビュー":
     mask = (snap[key] >= v) if cmp_mode == "以上" else (snap[key] <= v)
     codes_by_slope = set(snap.loc[mask, "product_code"])
 
-    shape_df = shape_flags(year_df, window=max(8, n_win * 2),
-                            alpha_ratio=0.02 * (1.0 - sens), amp_ratio=0.06 * (1.0 - sens))
+    eff_n = n_win if n_win > 0 else 12
+    shape_df = shape_flags(
+        year_df,
+        window=max(6, eff_n * 2),
+        alpha_ratio=0.02 * (1.0 - sens),
+        amp_ratio=0.06 * (1.0 - sens),
+    )
     codes_steep = set(snap.loc[snap["slope_z"].abs() >= z_thr, "product_code"])
     codes_mtn = set(shape_df.loc[shape_df["is_mountain"], "product_code"])
     codes_val = set(shape_df.loc[shape_df["is_valley"], "product_code"])

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -118,7 +118,14 @@ def toolbar_sku_detail(multi_mode: bool):
             )
             ui["quick"] = quick
         with k:
-            n_win = st.slider("傾きウィンドウ（月）", 3, 12, ui.get("n_win", 6), 1)
+            n_win = st.slider(
+                "傾きウィンドウ（月）",
+                0,
+                12,
+                ui.get("n_win", 6),
+                1,
+                help="0=自動（系列の全期間で判定）",
+            )
             ui["n_win"] = n_win
             cmp_opts = ["以上", "未満"]
             cmp_mode = st.radio(
@@ -207,9 +214,10 @@ def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
                 quick_codes = snapshot["product_code"]
             codes_by_slope = codes_by_slope & set(quick_codes)
         if sc["shape_pick"] != "（なし）":
+            eff_n = sc["n_win"] if sc["n_win"] > 0 else 12
             sh = shape_flags(
                 dfp,
-                window=max(8, sc["n_win"] * 2),
+                window=max(6, eff_n * 2),
                 alpha_ratio=0.02 * (1.0 - sc["sens"]),
                 amp_ratio=0.06 * (1.0 - sc["sens"]),
             )

--- a/services.py
+++ b/services.py
@@ -595,12 +595,21 @@ def trend_last6(series: pd.Series) -> dict:
 
 
 def slope_last_n(y: pd.Series, n: int = 6):
-    """末尾n点で単回帰の傾き（円/月）と%/月を返す。"""
-    s = y.dropna().tail(n)
-    if len(s) < 3:
-        return np.nan, np.nan
-    x = np.arange(len(s), dtype=float)
-    m, _ = np.polyfit(x, s.values.astype(float), 1)
+    """末尾n点で単回帰の傾き（円/月）と%/月を返す。
+
+    n<=0（またはNone）の場合は全期間を対象とし、
+    データ点が2点未満ならNaNを返す。
+    """
+    s = y.dropna()
+    s = s if (n is None or n <= 0) else s.tail(n)
+    L = len(s)
+    if L < 2:
+        return np.nan, np.nan  # データが足りない
+    x = np.arange(L, dtype=float)
+    if L == 2:
+        m = s.iloc[1] - s.iloc[0]
+    else:
+        m, _ = np.polyfit(x, s.values.astype(float), 1)
     ratio = m / max(1.0, s.mean())  # %/月相当
     return float(m), float(ratio)
 

--- a/tests/test_slope.py
+++ b/tests/test_slope.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from services import slope_last_n, slopes_snapshot
+
+
+def test_slope_last_n_all_period():
+    s = pd.Series([1, 2, 3, 4, 5])
+    m, r = slope_last_n(s, n=0)
+    assert m == pytest.approx(1.0)
+    assert r == pytest.approx(1 / 3)
+
+
+def test_slope_last_n_insufficient_and_two_points():
+    s_one = pd.Series([1])
+    m1, r1 = slope_last_n(s_one, n=6)
+    assert np.isnan(m1) and np.isnan(r1)
+
+    s_two = pd.Series([1, 3])
+    m2, r2 = slope_last_n(s_two, n=6)
+    assert m2 == pytest.approx(2.0)
+    assert r2 == pytest.approx(1.0)
+
+
+def test_slopes_snapshot_handles_small_series():
+    df = pd.DataFrame(
+        {
+            "product_code": ["A", "A", "B"],
+            "month": [1, 2, 1],
+            "year_sum": [1, 2, 1],
+        }
+    )
+    snap = slopes_snapshot(df, n=0)
+    a_slope = snap.loc[snap.product_code == "A", "slope_yen"].iloc[0]
+    b_slope = snap.loc[snap.product_code == "B", "slope_yen"].iloc[0]
+    assert a_slope == pytest.approx(1.0)
+    assert np.isnan(b_slope)
+


### PR DESCRIPTION
## Summary
- Allow slope window slider to select 0 for auto mode using entire series
- Guard slope calculations against n<=0 and too few data points
- Add regression window fallback for shape extraction when window is 0
- Cover slope guards with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30ea63be08323bb8d11c286a4991b