### PR TITLE
Add lightweight forecasting and anomaly detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -703,6 +703,12 @@ elif page == "比較ビュー":
         max_labels=label_max,
         alt_side=alternate_side,
         slope_conf=None,
+        forecast_method="なし",
+        forecast_window=12,
+        forecast_horizon=6,
+        forecast_k=2.0,
+        forecast_robust=False,
+        anomaly="OFF",
     )
 
     st.markdown('<div class="chart-body">', unsafe_allow_html=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ reportlab>=4.0
 pyarrow
 duckdb
 statsmodels
-pmdarima
 python-pptx
 scipy
 scikit-learn

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services import (
+    forecast_linear_band,
+    forecast_holt_linear,
+    band_from_moving_stats,
+    detect_linear_anomalies,
+)
+
+def test_forecast_linear_band_basic():
+    s = pd.Series([1, 2, 3, 4, 5, 6])
+    f, lo, hi = forecast_linear_band(s, window=6, horizon=3, k=2.0)
+    assert len(f) == 3
+    assert np.allclose(f, [7, 8, 9])
+    assert np.allclose(lo, hi)
+
+def test_forecast_holt_linear_trend():
+    s = pd.Series([1, 2, 3, 4])
+    f = forecast_holt_linear(s, alpha=1.0, beta=1.0, horizon=2)
+    assert np.allclose(f, [5, 6])
+
+def test_band_from_moving_stats_mean():
+    s = pd.Series([1, 2, 3, 4, 5, 6])
+    f, lo, hi = band_from_moving_stats(s, window=3, horizon=2, k=1.0)
+    assert np.allclose(f, [5, 5])
+    assert lo[0] < f[0] < hi[0]
+
+def test_detect_linear_anomalies():
+    s = pd.Series([1, 1, 1, 1, 10, 1, 1])
+    res = detect_linear_anomalies(s, window=3, threshold=2.5, robust=False)
+    assert not res.empty
+    assert 4 in res["month"].values


### PR DESCRIPTION
## Summary
- implement NumPy/pandas forecasting utilities: local linear, Holt linear, moving average bands
- add anomaly detection based on local linear residuals
- expose forecast options in toolbar and render forecast bands and alerts
- drop unused pmdarima dependency

## Testing
- `ruff check services.py core/chart_card.py tests/test_forecast.py app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b313d36a348323aa57750b88909fd2