### PR TITLE
style: apply McKinsey-inspired theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,8 +11,16 @@ import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 
-# Apply colorblind-friendly palette across figures
-px.defaults.color_discrete_sequence = px.colors.qualitative.Safe
+# McKinsey inspired palette
+MCKINSEY_PALETTE = [
+    "#003a70",  # deep navy
+    "#8fb8de",  # light blue
+    "#5b6770",  # grey
+    "#b1b3b3",  # light grey
+    "#243746",  # dark slate
+]
+# Apply palette across figures
+px.defaults.color_discrete_sequence = MCKINSEY_PALETTE
 
 PLOTLY_CONFIG = {
     "locale": "ja",
@@ -55,6 +63,37 @@ from core.chart_card import toolbar_sku_detail, build_chart_card
 
 APP_TITLE = "売上年計（12カ月移動累計）ダッシュボード"
 st.set_page_config(page_title=APP_TITLE, layout="wide", initial_sidebar_state="expanded")
+
+# Global styling to evoke McKinsey's understated aesthetic
+st.markdown(
+    """
+    <style>
+    :root {
+        --color-primary: #003a70;
+        --color-accent: #8fb8de;
+        --background-color: #f2f4f5;
+        --card-bg: #ffffff;
+    }
+    [data-testid="stApp"] {
+        background-color: var(--background-color);
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        color: #1b1b1d;
+    }
+    .stSidebar {
+        background-color: var(--color-primary);
+    }
+    .stSidebar, .stSidebar a {
+        color: white !important;
+    }
+    .stButton>button {
+        background-color: var(--color-primary);
+        color: white;
+        border-radius: 4px;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # ---------------- Session State ----------------
 if "data_monthly" not in st.session_state:

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -29,15 +29,15 @@ def _ensure_css():
         """
 <style>
 .chart-card { position: relative; margin:.25rem 0 1rem; border-radius:12px;
-  border:1px solid rgba(113,178,255,.25); background:var(--background-color,#0f172a); }
+  border:1px solid var(--color-primary); background:var(--card-bg,#fff); }
 .chart-toolbar { position: sticky; top: -1px; z-index: 5;
   display:flex; gap:.6rem; flex-wrap:wrap; align-items:center;
-  padding:.35rem .6rem; background: linear-gradient(180deg, rgba(113,178,255,.20), rgba(113,178,255,.10));
-  border-bottom:1px solid rgba(113,178,255,.35); }
+  padding:.35rem .6rem; background: linear-gradient(180deg, rgba(0,58,112,.08), rgba(0,58,112,.02));
+  border-bottom:1px solid var(--color-primary); }
 .chart-toolbar .stRadio, .chart-toolbar .stSelectbox, .chart-toolbar .stSlider,
 .chart-toolbar .stMultiSelect, .chart-toolbar .stCheckbox { margin-bottom:0 !important; }
-.chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:#e6f2ff; }
-.chart-toolbar .stSlider label { color:#e6f2ff; }
+.chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:#003a70; }
+.chart-toolbar .stSlider label { color:#003a70; }
 .chart-body { padding:.15rem .4rem .4rem; }
 </style>
 """,


### PR DESCRIPTION
## Summary
- introduce McKinsey-inspired color palette and global CSS to reinforce a refined, corporate aesthetic
- align chart components with the new palette for consistent styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b459341f0883238953b211fa4cce1a