### PR TITLE
Improve chart toolbar readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -528,16 +528,16 @@ elif page == "比較ビュー":
         """
 <style>
 .chart-card { position: relative; margin:.25rem 0 1rem; border-radius:12px;
-  border:1px solid rgba(113,178,255,.25); background:var(--background-color,#0f172a); }
+  border:1px solid var(--color-primary); background:var(--card-bg,#fff); }
 .chart-toolbar { position: sticky; top: -1px; z-index: 5;
   display:flex; gap:.6rem; flex-wrap:wrap; align-items:center;
-  padding:.35rem .6rem; background: linear-gradient(180deg, rgba(113,178,255,.20), rgba(113,178,255,.10));
-  border-bottom:1px solid rgba(113,178,255,.35); }
+  padding:.35rem .6rem; background: linear-gradient(180deg, rgba(0,58,112,.08), rgba(0,58,112,.02));
+  border-bottom:1px solid var(--color-primary); }
 /* Streamlit標準の下マージンを除去（ここが距離の主因） */
 .chart-toolbar .stRadio, .chart-toolbar .stSelectbox, .chart-toolbar .stSlider,
 .chart-toolbar .stMultiSelect, .chart-toolbar .stCheckbox { margin-bottom:0 !important; }
-.chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:#e6f2ff; }
-.chart-toolbar .stSlider label { color:#e6f2ff; }
+.chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:#003a70; }
+.chart-toolbar .stSlider label { color:#003a70; }
 .chart-body { padding:.15rem .4rem .4rem; }
 </style>
         """,


### PR DESCRIPTION
## Summary
- Enhance chart toolbar styling with higher contrast labels and consistent card colors

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59eae18908323a2c38eb3cf8c8438