### PR TITLE
feat: add global plot style customization

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 from ai_features import summarize_dataframe, generate_comment, explain_analysis
+from core.style_prefs import DEFAULT_PALETTES, get_style_prefs, apply_user_style
 
 # McKinsey inspired palette
 MCKINSEY_PALETTE = [
@@ -118,6 +119,10 @@ if "tags" not in st.session_state:
     st.session_state.tags = {}  # product_code -> List[str]
 if "saved_views" not in st.session_state:
     st.session_state.saved_views = {}  # name -> dict
+if "style_prefs" not in st.session_state:
+    st.session_state.style_prefs = {}
+if "style_prefs_page" not in st.session_state:
+    st.session_state.style_prefs_page = {}
 if "compare_params" not in st.session_state:
     st.session_state.compare_params = {}
 if "compare_results" not in st.session_state:
@@ -254,6 +259,93 @@ def winsorize_frame(df, cols, p: float = 0.01):
     return out
 
 
+def style_customizer(labels: List[str], page_key: str) -> None:
+    """Display style customization UI and persist preferences."""
+    with st.expander("🎨 表示カスタマイズ", expanded=False):
+        scope = st.radio("適用対象", ["すべてのページ", "このページのみ"], horizontal=True)
+        if scope == "すべてのページ":
+            prefs = st.session_state.setdefault("style_prefs", {})
+        else:
+            st.session_state.setdefault("style_prefs_page", {})
+            prefs = st.session_state["style_prefs_page"].setdefault(page_key, {})
+
+        c1, c2, c3 = st.columns(3)
+        with c1:
+            plot_bg = st.color_picker("プロット背景", value=prefs.get("plot_bgcolor", "#0F172A"))
+            paper_bg = st.color_picker("紙背景", value=prefs.get("paper_bgcolor", "#0F172A"))
+            text_c = st.color_picker("文字色", value=prefs.get("text_color", "#E6F2FF"))
+        with c2:
+            grid_c = st.color_picker("グリッド色", value=prefs.get("grid_color", "rgba(255,255,255,.08)"))
+            palette = st.selectbox("カラーパレット", list(DEFAULT_PALETTES.keys()), index=list(DEFAULT_PALETTES.keys()).index(prefs.get("palette", "Default")))
+            legend_pos = st.selectbox("凡例位置", ["右", "上", "下", "左"], index=["右", "上", "下", "左"].index(prefs.get("legend_pos", "右")))
+        with c3:
+            line_w = st.slider("線の太さ", 0.8, 4.0, float(prefs.get("line_width", 2.2)))
+            line_dash = st.selectbox("線のスタイル", ["実線", "点線", "破線", "点破線"], index=["実線", "点線", "破線", "点破線"].index(prefs.get("line_dash", "実線")))
+            marker_size = st.slider("ノードサイズ", 0, 12, int(prefs.get("marker_size", 6)))
+            marker_symbol = st.selectbox("ノード形状", ["circle", "square", "diamond", "cross", "triangle-up"], index=["circle", "square", "diamond", "cross", "triangle-up"].index(prefs.get("marker_symbol", "circle")))
+            marker_edge_c = st.color_picker("ノード縁色", value=prefs.get("marker_edge_c", "#FFFFFF"))
+            marker_edge_w = st.slider("ノード縁太さ", 0.0, 3.0, float(prefs.get("marker_edge_w", 1.0)))
+
+        show_grid = st.checkbox("グリッド表示", value=prefs.get("show_grid", True))
+        bold_axis = st.checkbox("目盛・軸ラインを濃く", value=prefs.get("bold_axis", False))
+        band_alpha = st.slider("予測帯の透明度", 0.0, 0.6, float(prefs.get("band_alpha", 0.18)), 0.02)
+
+        with st.expander("系列カラー手動指定（任意）", expanded=False):
+            for name in sorted(labels)[:100]:
+                prefs.setdefault("series_colors", {})
+                prefs["series_colors"][name] = st.color_picker(name, value=prefs["series_colors"].get(name, ""))
+
+        prefs.update(
+            dict(
+                plot_bgcolor=plot_bg,
+                paper_bgcolor=paper_bg,
+                text_color=text_c,
+                grid_color=grid_c,
+                palette=palette,
+                legend_pos=legend_pos,
+                line_width=line_w,
+                line_dash=line_dash,
+                marker_size=marker_size,
+                marker_symbol=marker_symbol,
+                marker_edge_c=marker_edge_c,
+                marker_edge_w=marker_edge_w,
+                show_grid=show_grid,
+                bold_axis=bold_axis,
+                band_alpha=band_alpha,
+            )
+        )
+
+        if scope == "すべてのページ":
+            st.session_state["style_prefs"] = prefs
+        else:
+            st.session_state["style_prefs_page"][page_key] = prefs
+
+        colA, colB, colC = st.columns([1, 1, 1])
+        with colA:
+            st.download_button(
+                "JSONとして保存",
+                data=json.dumps(prefs, ensure_ascii=False, indent=2).encode("utf-8"),
+                file_name="style_prefs.json",
+                mime="application/json",
+            )
+        with colB:
+            up = st.file_uploader("JSONを読み込み", type=["json"])
+            if up is not None:
+                loaded = json.load(up)
+                if scope == "すべてのページ":
+                    st.session_state["style_prefs"] = loaded
+                else:
+                    st.session_state["style_prefs_page"][page_key] = loaded
+                st.success("読み込み完了。表示を更新しました。")
+        with colC:
+            if st.button("既定に戻す"):
+                if scope == "すべてのページ":
+                    st.session_state.pop("style_prefs", None)
+                else:
+                    st.session_state.get("style_prefs_page", {}).pop(page_key, None)
+                st.experimental_rerun()
+
+
 def maybe_log1p(df, cols, enable: bool):
     if not enable:
         return df
@@ -323,6 +415,19 @@ page = st.sidebar.radio(
     ],
 )
 
+page_key_map = {
+    "ダッシュボード": "dashboard",
+    "ランキング": "ranking",
+    "比較ビュー": "compare",
+    "SKU詳細": "sku_detail",
+    "相関分析": "corr",
+    "データ取込": "upload",
+    "アラート": "alerts",
+    "設定": "settings",
+    "保存ビュー": "saved",
+}
+st.session_state["current_page"] = page_key_map.get(page, "default")
+
 # ---------------- Pages ----------------
 
 # 1) データ取込
@@ -391,6 +496,10 @@ if page == "データ取込":
 elif page == "ダッシュボード":
     require_data()
     st.header("ダッシュボード")
+    labels_all = (
+        st.session_state.data_year["product_name"].fillna(st.session_state.data_year["product_code"]).unique().tolist()
+    )
+    style_customizer(labels_all, st.session_state.get("current_page", "dashboard"))
 
     # Command bar (期間/単位)
     with st.container():
@@ -465,6 +574,8 @@ elif page == "ダッシュボード":
     fig = px.line(totals, x="month", y="year_sum_disp", title="総合 年計トレンド", markers=True)
     fig.update_yaxes(title=f"年計({unit})")
     fig.update_layout(height=350, margin=dict(l=10, r=10, t=50, b=10))
+    prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+    fig = apply_user_style(fig, prefs)
     st.plotly_chart(fig, use_container_width=True, config=PLOTLY_CONFIG)
 
     # ランキング（年計）
@@ -493,6 +604,10 @@ elif page == "ダッシュボード":
 elif page == "ランキング":
     require_data()
     st.header("ランキング / ワースト")
+    labels_all = (
+        st.session_state.data_year["product_name"].fillna(st.session_state.data_year["product_code"]).unique().tolist()
+    )
+    style_customizer(labels_all, st.session_state.get("current_page", "ranking"))
     end_m = end_month_selector(st.session_state.data_year, key="end_month_rank")
     metric = st.selectbox("指標", options=["year_sum","yoy","delta","slope_beta"], index=0)
     order = st.radio("並び順", options=["desc","asc"], horizontal=True)
@@ -514,6 +629,8 @@ elif page == "ランキング":
     st.caption(f"除外 {zero_cnt} 件 / 全 {total} 件")
 
     fig_bar = px.bar(snap.head(20), x="product_name", y=metric)
+    prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+    fig_bar = apply_user_style(fig_bar, prefs)
     st.plotly_chart(fig_bar, use_container_width=True, config=PLOTLY_CONFIG)
 
     if ai_on and not snap.empty:
@@ -543,6 +660,10 @@ elif page == "ランキング":
 elif page == "比較ビュー":
     require_data()
     st.header("マルチ商品比較")
+    labels_all = (
+        st.session_state.data_year["product_name"].fillna(st.session_state.data_year["product_code"]).unique().tolist()
+    )
+    style_customizer(labels_all, st.session_state.get("current_page", "compare"))
     params = st.session_state.compare_params
     year_df = st.session_state.data_year
     end_m = end_month_selector(year_df, key="compare_end_month")
@@ -841,6 +962,8 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
         pass
 
     with st.expander("分布（オプション）", expanded=False):
+        prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+        hist_fig = apply_user_style(hist_fig, prefs)
         st.plotly_chart(hist_fig, use_container_width=True)
 
     # ---- Small Multiples ----
@@ -861,6 +984,7 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
     col_count = 4
     cols = st.columns(col_count)
     ymax = df_long[df_long["product_code"].isin(main_codes)]["year_sum"].max() / UNIT_MAP[unit] if share_y else None
+    prefs = get_style_prefs(st.session_state.get("current_page", "default"))
     for i, code in enumerate(page_codes):
         g = df_long[df_long["product_code"] == code]
         disp = g["display_name"].iloc[0] if not g.empty else code
@@ -889,6 +1013,7 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
         else:
             fig_s.update_layout(hovermode="x unified", hoverlabel=dict(align="left"))
         last_val = g.sort_values("month")["year_sum"].iloc[-1] / UNIT_MAP[unit] if not g.empty else np.nan
+        fig_s = apply_user_style(fig_s, prefs)
         with cols[i % col_count]:
             st.metric(disp, f"{last_val:,.0f} {unit}" if not np.isnan(last_val) else "—")
             st.plotly_chart(
@@ -902,6 +1027,10 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
 elif page == "SKU詳細":
     require_data()
     st.header("SKU 詳細")
+    labels_all = (
+        st.session_state.data_year["product_name"].fillna(st.session_state.data_year["product_code"]).unique().tolist()
+    )
+    style_customizer(labels_all, st.session_state.get("current_page", "sku_detail"))
     end_m = end_month_selector(st.session_state.data_year, key="end_month_detail")
     prods = st.session_state.data_year[["product_code", "product_name"]].drop_duplicates().sort_values("product_code")
     mode = st.radio("表示モード", ["単品", "複数比較"], horizontal=True)
@@ -990,6 +1119,10 @@ elif page == "SKU詳細":
 elif page == "相関分析":
     require_data()
     st.header("相関分析")
+    labels_all = (
+        st.session_state.data_year["product_name"].fillna(st.session_state.data_year["product_code"]).unique().tolist()
+    )
+    style_customizer(labels_all, st.session_state.get("current_page", "corr"))
     end_m = end_month_selector(st.session_state.data_year, key="corr_end_month")
     snapshot = latest_yearsum_snapshot(st.session_state.data_year, end_m)
 
@@ -1038,6 +1171,8 @@ elif page == "相関分析":
         st.caption("右上=強い正、左下=強い負、白=関係薄")
         corr = df_plot[metrics].corr(method=method)
         fig_corr = px.imshow(corr, color_continuous_scale="RdBu_r", zmin=-1, zmax=1, text_auto=True)
+        prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+        fig_corr = apply_user_style(fig_corr, prefs)
         st.plotly_chart(fig_corr, use_container_width=True, config=PLOTLY_CONFIG)
 
         st.subheader("ペア・エクスプローラ")
@@ -1071,6 +1206,8 @@ elif page == "相関分析":
             for _, row in outliers.iterrows():
                 label = row["product_name"] or row["product_code"]
                 fig_sc.add_annotation(x=row[x_col], y=row[y_col], text=label, showarrow=True, arrowhead=1)
+            prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+            fig_sc = apply_user_style(fig_sc, prefs)
             st.plotly_chart(fig_sc, use_container_width=True, config=PLOTLY_CONFIG)
             st.caption("rは -1〜+1。0は関連が薄い。CIに0を含まなければ有意。")
             st.caption("散布図の点が右上・左下に伸びれば正、右下・左上なら負。")

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import streamlit as st
+from core.style_prefs import get_style_prefs, apply_user_style
 
 from services import (
     slopes_snapshot,
@@ -370,7 +371,8 @@ def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
             min_gap_px=tb["gap_px"],
             alternate_side=tb["alt_side"],
         )
-
+    prefs = get_style_prefs(st.session_state.get("current_page", "default"))
+    fig = apply_user_style(fig, prefs)
     st.plotly_chart(
         fig,
         use_container_width=True,

--- a/core/style_prefs.py
+++ b/core/style_prefs.py
@@ -1,0 +1,105 @@
+import json
+from typing import Dict
+
+import streamlit as st
+
+DEFAULT_PALETTES = {
+    "Default": None,  # Plotly既定
+    "Contrast": ["#1f77b4","#d62728","#2ca02c","#ff7f0e","#9467bd","#17becf","#7f7f7f","#bcbd22"],
+    "Pastel":   ["#8ecae6","#ffb5a7","#c1d3fe","#bde0fe","#caffbf","#ffd6a5","#d0bdf4","#ffc8dd"],
+    "Colorblind": ["#0072B2","#D55E00","#009E73","#CC79A7","#F0E442","#56B4E9","#E69F00","#000000"],
+}
+
+
+def get_style_prefs(page_key: str) -> Dict:
+    """グローバル or ページ専用のスタイル設定を取得"""
+    pg = st.session_state.get("style_prefs_page", {}).get(page_key, {})
+    gl = st.session_state.get("style_prefs", {})
+    return {**gl, **pg}  # ページが優先
+
+
+def apply_user_style(fig, prefs: Dict):
+    """ユーザー指定のスタイルを最終適用（全グラフ共通）"""
+    if not prefs:
+        return fig
+
+    paper = prefs.get("paper_bgcolor")
+    plot = prefs.get("plot_bgcolor")
+    textc = prefs.get("text_color")
+    gridc = prefs.get("grid_color")
+    accent = prefs.get("accent")
+    pal = prefs.get("palette")
+    if pal in DEFAULT_PALETTES and DEFAULT_PALETTES[pal]:
+        fig.update_layout(colorway=DEFAULT_PALETTES[pal])
+    fig.update_layout(
+        paper_bgcolor=paper or fig.layout.paper_bgcolor,
+        plot_bgcolor=plot or fig.layout.plot_bgcolor,
+        font=dict(color=textc) if textc else fig.layout.font,
+        legend=(
+            dict(y=1, x=1.02, yanchor="top", xanchor="left")
+            if prefs.get("legend_pos", "右") == "右"
+            else (
+                dict(orientation="h", y=1.08, x=0, yanchor="bottom")
+                if prefs.get("legend_pos") == "上"
+                else (
+                    dict(orientation="h", y=-0.2, x=0)
+                    if prefs.get("legend_pos") == "下"
+                    else dict(y=1, x=-0.02, yanchor="top", xanchor="right")
+                )
+            )
+        ),
+    )
+    # 軸・グリッド
+    show_grid = prefs.get("show_grid", True)
+    fig.update_xaxes(
+        showgrid=show_grid,
+        gridcolor=gridc or "rgba(255,255,255,.08)",
+        linecolor="rgba(255,255,255,.25)" if prefs.get("bold_axis") else None,
+    )
+    fig.update_yaxes(
+        showgrid=show_grid,
+        gridcolor=gridc or "rgba(255,255,255,.08)",
+        linecolor="rgba(255,255,255,.25)" if prefs.get("bold_axis") else None,
+    )
+
+    # 線・ノード
+    lw = float(prefs.get("line_width", 2.2))
+    dash_map = {"実線": None, "点線": "dot", "破線": "dash", "点破線": "dashdot"}
+    dash = dash_map.get(prefs.get("line_dash", "実線"))
+    ms = int(prefs.get("marker_size", 6))
+    if ms <= 0:
+        fig.update_traces(mode="lines")
+    else:
+        fig.update_traces(mode="lines+markers")
+    fig.update_traces(line=dict(width=lw, dash=dash), selector=dict(mode="lines"))
+    marker_line = dict(
+        width=float(prefs.get("marker_edge_w", 1)),
+        color=prefs.get("marker_edge_c", "#FFFFFF"),
+    )
+    fig.update_traces(
+        selector=lambda t: "markers" in (t.mode or ""),
+        marker=dict(size=ms, line=marker_line, symbol=prefs.get("marker_symbol", "circle")),
+    )
+
+    # 予測帯などの塗り透明度
+    fill_alpha = float(prefs.get("band_alpha", 0.18))
+    if accent and accent.startswith("rgba"):
+        for tr in fig.data:
+            if getattr(tr, "fill", None) in ("tonexty", "tozeroy"):
+                fig.update_traces(
+                    selector=lambda t, uid=tr.uid: t.uid == uid,
+                    fillcolor=accent.replace(")", f",{fill_alpha})"),
+                )
+
+    # 系列色の手動指定
+    manual = prefs.get("series_colors", {})
+    if manual:
+        for tr in fig.data:
+            name = (tr.name or "").split("：")[0]
+            if name in manual and manual[name]:
+                fig.update_traces(
+                    selector=lambda t, uid=tr.uid: t.uid == uid,
+                    line=dict(color=manual[name]),
+                    marker=dict(color=manual[name]),
+                )
+    return fig


### PR DESCRIPTION
## Summary
- add shared style preference helper with multiple color palettes
- allow users to tweak graph appearance via "🎨 表示カスタマイズ" expander
- apply saved styles to all Plotly charts across pages

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a7d46008832389d15ed903d3f819