### PR TITLE
Add per-chart style panel for Plotly graphs

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -12,7 +12,7 @@ from services import (
     band_from_moving_stats,
     detect_linear_anomalies,
 )
-from core.plot_utils import add_latest_labels_no_overlap
+from core.plot_utils import add_latest_labels_no_overlap, styled_plotly_chart
 
 UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
 
@@ -219,7 +219,7 @@ def toolbar_sku_detail(multi_mode: bool):
     )
 
 
-def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
+def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None, key="chart"):
     months = {"12ヶ月": 12, "24ヶ月": 24, "36ヶ月": 36}[tb["period"]]
     dfp = df_long.sort_values("month").groupby("product_code").tail(months)
     if selected_codes:
@@ -371,8 +371,9 @@ def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
             alternate_side=tb["alt_side"],
         )
 
-    st.plotly_chart(
+    styled_plotly_chart(
         fig,
+        key=key,
         use_container_width=True,
         config={"displaylogo": False, "scrollZoom": True, "doubleClick": "reset"},
     )

--- a/core/plot_utils.py
+++ b/core/plot_utils.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import numpy as np
 import plotly.graph_objects as go
+import streamlit as st
+import json
 
 
 def _plot_area_height(fig: go.Figure) -> int:
@@ -63,3 +65,82 @@ def add_latest_labels_no_overlap(
             bordercolor="rgba(0,0,0,0)",
             font=dict(size=font_size),
         )
+
+
+DEFAULT_STYLE = {
+    "theme": "light",
+    "bgcolor": "#ffffff",
+    "line_color": "#003a70",
+    "marker_color": "#003a70",
+    "legend": True,
+    "grid": True,
+}
+
+
+def styled_plotly_chart(
+    fig: go.Figure,
+    *,
+    key: str,
+    config: dict | None = None,
+    **kwargs,
+):
+    """Render Plotly figure with an attached style panel."""
+
+    global_style = st.session_state.setdefault("global_style", DEFAULT_STYLE.copy())
+    style_map = st.session_state.setdefault("plot_styles", {})
+    style = style_map.get(key, global_style.copy())
+
+    col_ctrl, col_chart = st.columns([0.06, 0.94])
+    with col_ctrl:
+        with st.popover("🎛", key=f"{key}_popover"):
+            theme_idx = 1 if style.get("theme") == "dark" else 0
+            style["theme"] = st.radio("テーマ", ["light", "dark"], index=theme_idx, key=f"{key}_theme")
+            style["bgcolor"] = st.color_picker(
+                "背景色", value=style.get("bgcolor", "#ffffff"), key=f"{key}_bg"
+            )
+            style["line_color"] = st.color_picker(
+                "線色", value=style.get("line_color", "#003a70"), key=f"{key}_line"
+            )
+            style["marker_color"] = st.color_picker(
+                "ノード色", value=style.get("marker_color", "#003a70"), key=f"{key}_marker"
+            )
+            style["legend"] = st.checkbox(
+                "凡例", value=style.get("legend", True), key=f"{key}_legend"
+            )
+            style["grid"] = st.checkbox(
+                "グリッド", value=style.get("grid", True), key=f"{key}_grid"
+            )
+            st.download_button(
+                "JSON保存",
+                data=json.dumps(style, ensure_ascii=False).encode("utf-8"),
+                file_name=f"{key}_style.json",
+                mime="application/json",
+                key=f"{key}_save",
+            )
+            uploaded = st.file_uploader("JSON読込", type="json", key=f"{key}_load")
+            if uploaded is not None:
+                try:
+                    loaded = json.load(uploaded)
+                    for k in DEFAULT_STYLE:
+                        if k in loaded:
+                            style[k] = loaded[k]
+                except Exception:
+                    st.warning("JSONの読み込みに失敗しました")
+
+    style_map[key] = style
+    st.session_state.plot_styles = style_map
+
+    template = "plotly_dark" if style["theme"] == "dark" else "plotly_white"
+    fig.update_layout(
+        template=template,
+        paper_bgcolor=style["bgcolor"],
+        plot_bgcolor=style["bgcolor"],
+        showlegend=style["legend"],
+    )
+    fig.update_xaxes(showgrid=style["grid"])
+    fig.update_yaxes(showgrid=style["grid"])
+    fig.update_traces(line_color=style["line_color"])
+    fig.update_traces(marker=dict(color=style["marker_color"]))
+
+    with col_chart:
+        st.plotly_chart(fig, config=config, **kwargs)


### PR DESCRIPTION
## Summary
- add `styled_plotly_chart` helper with per-figure popover for theme, colors, legend and grid plus JSON import/export
- route all Plotly charts through the new helper so individual graphs can override global styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_features')*

------
https://chatgpt.com/codex/tasks/task_e_68b5b55a19008323ab7428fac34cd609