### PR TITLE
Format numeric inputs with comma separators

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -17,6 +17,21 @@ from core.plot_utils import add_latest_labels_no_overlap, apply_elegant_theme
 UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
 
 
+def format_int(val: float | int) -> str:
+    try:
+        return f"{int(val):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def int_input(label: str, value: int) -> int:
+    text = st.text_input(label, format_int(value))
+    try:
+        return int(text.replace(",", ""))
+    except ValueError:
+        return value
+
+
 def marker_step(dates, target_points=24):
     n = len(pd.unique(dates))
     return max(1, round(n / target_points))
@@ -153,12 +168,15 @@ def toolbar_sku_detail(multi_mode: bool):
             )
             ui["thr_type"] = thr_type
         with m:
-            thr_val = st.number_input(
-                "しきい値",
-                value=float(ui.get("thr_val", 0.0)),
-                step=(10000.0 if thr_type == "円/月" else 0.01),
-                format="%.2f" if thr_type != "円/月" else "%.0f",
-            )
+            if thr_type == "円/月":
+                thr_val = int_input("しきい値", int(ui.get("thr_val", 0)))
+            else:
+                thr_val = st.number_input(
+                    "しきい値",
+                    value=float(ui.get("thr_val", 0.0)),
+                    step=0.01,
+                    format="%.2f",
+                )
             ui["thr_val"] = float(thr_val)
         s1, s2 = st.columns([1.2, 1.2])
         with s1:


### PR DESCRIPTION
## Summary
- Ensure monetary sliders and inputs drop decimal fractions and show comma-separated values
- Add `format_int` and `int_input` helpers for consistent thousand-separated integer display
- Apply integer formatting to threshold and width parameters in comparison and chart components

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61abc65708323922897e96919b316