### PR TITLE
Avoid AttributeError in apply_elegant_theme

### DIFF
--- a/core/plot_utils.py
+++ b/core/plot_utils.py
@@ -60,7 +60,7 @@ def apply_elegant_theme(fig: go.Figure, theme: str = "dark") -> go.Figure:
     )
     fig.update_traces(selector=dict(mode="lines"), line=dict(width=2.0))
     fig.update_traces(
-        selector=lambda t: "markers" in (t.mode or ""),
+        selector=lambda t: "markers" in getattr(t, "mode", ""),
         marker=dict(size=5, line=dict(width=1, color="white")),
     )
     return fig


### PR DESCRIPTION
## Summary
- Guard against traces without a `mode` attribute when styling markers

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61ccd351c8323afd44dec0037f7ae