### PR TITLE
Increase chart heights for better readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -578,7 +578,7 @@ elif page == "ダッシュボード":
         totals, x="month", y="year_sum_disp", title="総合 年計トレンド", markers=True
     )
     fig.update_yaxes(title=f"年計({unit})", tickformat="~,d")
-    fig.update_layout(height=350, margin=dict(l=10, r=10, t=50, b=10))
+    fig.update_layout(height=525, margin=dict(l=10, r=10, t=50, b=10))
     fig = apply_elegant_theme(fig, theme=st.session_state.get("ui_theme", "dark"))
     st.plotly_chart(fig, use_container_width=True, config=PLOTLY_CONFIG)
 
@@ -1126,7 +1126,7 @@ zスコア：全SKUの傾き分布に対する標準化。|z|≥1.5で急勾配�
             st.plotly_chart(
                 fig_s,
                 use_container_width=True,
-                height=150,
+                height=225,
                 config=PLOTLY_CONFIG,
             )
 

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -493,6 +493,7 @@ def build_chart_card(df_long, selected_codes, multi_mode, tb, band_range=None):
     st.plotly_chart(
         fig,
         use_container_width=True,
+        height=600,
         config={"displaylogo": False, "scrollZoom": True, "doubleClick": "reset"},
     )
     return fig


### PR DESCRIPTION
## Summary
- expand total yearly trend chart height to make lines easier to read
- enlarge small multiple charts for clearer per‑SKU comparison
- set main comparison chart to taller default for improved overview

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b62539a7888323a55cc39d5e0e861f