### PR TITLE
Enhance anomaly insights, theme, and chart controls

### DIFF
--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -1,8 +1,11 @@
 import pandas as pd
 
-import pandas as pd
-
-from ai_features import summarize_dataframe, generate_comment, explain_analysis
+from ai_features import (
+    summarize_dataframe,
+    generate_comment,
+    explain_analysis,
+    generate_anomaly_brief,
+)
 
 
 def test_summarize_dataframe_returns_text():
@@ -22,3 +25,24 @@ def test_explain_analysis_returns_text():
     txt = explain_analysis({"売上": 1200, "前年比": 1.05})
     assert isinstance(txt, str)
     assert "売上" in txt or len(txt) > 0
+
+
+def test_generate_anomaly_brief_handles_data():
+    df = pd.DataFrame(
+        {
+            "product_name": ["A", "B"],
+            "month": ["2023-12", "2023-12"],
+            "score": [3.2, -2.8],
+            "year_sum": [1200000, 800000],
+            "yoy": [0.12, -0.05],
+            "delta": [50000, -30000],
+        }
+    )
+    txt = generate_anomaly_brief(df)
+    assert isinstance(txt, str)
+    assert len(txt) > 0
+
+
+def test_generate_anomaly_brief_empty():
+    txt = generate_anomaly_brief(pd.DataFrame())
+    assert "異常値は検出されませんでした" in txt


### PR DESCRIPTION
## Summary
- restyle the Streamlit app with a pastel McKinsey-inspired theme and add cached AI anomaly summaries
- upgrade the SKU detail toolbar with keyed widgets, fullscreen modal support, and configurable chart height
- introduce an anomaly detection page with threshold controls, AI highlights, and detailed charts
- enrich AI fallbacks and add tests for the new anomaly briefing helper

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cab12fcc5c8323a54a9207450697e8