### PR TITLE
Expand SKU comparison to 60 products

### DIFF
--- a/app.py
+++ b/app.py
@@ -1530,7 +1530,7 @@ elif page == "SKU詳細":
             )
     else:
         opts = (prods["product_code"] + " | " + prods["product_name"]).tolist()
-        sel = st.multiselect("SKU選択（最大30件）", options=opts, max_selections=30)
+        sel = st.multiselect("SKU選択（最大60件）", options=opts, max_selections=60)
         codes = [s.split(" | ")[0] for s in sel]
         if codes or (tb.get("slope_conf") and tb["slope_conf"].get("quick") != "なし"):
             build_chart_card(

--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -15,7 +15,7 @@ from services import (
 from core.plot_utils import add_latest_labels_no_overlap, apply_elegant_theme
 
 UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
-MAX_DISPLAY_PRODUCTS = 30
+MAX_DISPLAY_PRODUCTS = 60
 
 
 def format_int(val: float | int) -> str:

--- a/tests/test_chart_limit.py
+++ b/tests/test_chart_limit.py
@@ -4,8 +4,8 @@ from core.chart_card import limit_products, MAX_DISPLAY_PRODUCTS
 
 def test_limit_products_maximum():
     records = []
-    # create 40 products with increasing year_sum
-    for i in range(40):
+    # create 80 products with increasing year_sum
+    for i in range(80):
         code = f"P{i:03d}"
         for m in ["2024-01", "2024-02"]:
             records.append(
@@ -25,5 +25,5 @@ def test_limit_products_maximum():
     limited = limit_products(df, max_products=MAX_DISPLAY_PRODUCTS)
     assert limited["product_code"].nunique() == MAX_DISPLAY_PRODUCTS
     # ensure that the highest year_sum products are kept
-    expected_codes = {f"P{i:03d}" for i in range(40 - MAX_DISPLAY_PRODUCTS, 40)}
+    expected_codes = {f"P{i:03d}" for i in range(80 - MAX_DISPLAY_PRODUCTS, 80)}
     assert set(limited["product_code"].unique()) == expected_codes


### PR DESCRIPTION
## Summary
- allow selecting up to 60 SKUs in the SKU詳細 multiselect and underlying chart logic
- raise the chart card display limit to 60 SKUs and refresh the associated limit test

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cab7b91c6c83239ea32a9fecc6dc14